### PR TITLE
Fix two test suite issues

### DIFF
--- a/changelogd/changelogd.py
+++ b/changelogd/changelogd.py
@@ -52,7 +52,7 @@ class EntryField:
 
     @property
     def value(self) -> typing.Any:
-        value = None
+        value: typing.Any = None
         while value is None:
             modifiers = []
             if self.required:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ dev_requirements = [
 ]
 
 docs_requirements = [
+    "setuptools",
     "sphinx",
 ]
 


### PR DESCRIPTION
Hi,

Thanks a lot for writing and maintaining changelogd!

What do you think about these two changes that make the test suite pass again? Apparently something stopped depending on `setuptools`, so we need to bring it in explicitly to get `pkg_resources`, and recent versions of `mypy` will complain about a variable changing types in the middle of a function.

Thanks in advance for your time, and keep up the great work!