### PR TITLE
replace old "toml" with newer "tomli"/"tomllib"

### DIFF
--- a/changelog.d/other.e1a6bb44.entry.yaml
+++ b/changelog.d/other.e1a6bb44.entry.yaml
@@ -1,0 +1,5 @@
+message: Replace old "toml" with newer "tomli"/"tomllib".
+pr_ids:
+- '76'
+timestamp: 1755329213
+type: other

--- a/changelogd/config.py
+++ b/changelogd/config.py
@@ -7,9 +7,9 @@ import typing
 from copy import deepcopy
 from pathlib import Path
 
-try:
+if sys.version_info >= (3,11):
     import tomllib
-except ImportError:
+else:
     import tomli as tomllib
 
 import click

--- a/changelogd/config.py
+++ b/changelogd/config.py
@@ -68,7 +68,7 @@ DEFAULT_CONFIG.insert(
 def load_toml(path: Path) -> typing.Optional[str]:
     if not path.is_file():
         return None
-    with path.open('rb') as file_handle:
+    with path.open("rb") as file_handle:
         config = tomllib.load(file_handle)
 
     return config.get("tool", {}).get("changelogd", {}).get("config")  # type:ignore

--- a/changelogd/config.py
+++ b/changelogd/config.py
@@ -7,8 +7,12 @@ import typing
 from copy import deepcopy
 from pathlib import Path
 
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
 import click
-import toml
 from ruamel.yaml import YAML  # type: ignore
 from ruamel.yaml.comments import CommentedMap  # type: ignore
 
@@ -64,8 +68,8 @@ DEFAULT_CONFIG.insert(
 def load_toml(path: Path) -> typing.Optional[str]:
     if not path.is_file():
         return None
-    with path.open() as file_handle:
-        config = toml.load(file_handle)
+    with path.open('rb') as file_handle:
+        config = tomllib.load(file_handle)
 
     return config.get("tool", {}).get("changelogd", {}).get("config")  # type:ignore
 

--- a/changelogd/config.py
+++ b/changelogd/config.py
@@ -7,7 +7,7 @@ import typing
 from copy import deepcopy
 from pathlib import Path
 
-if sys.version_info >= (3,11):
+if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def flake8(session):
 
 @nox.session
 def mypy(session):
-    session.install("mypy", "types-toml", "types-click", "types-jinja2")
+    session.install("mypy", "types-click", "types-jinja2")
     session.run("mypy", "changelogd")
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "Click>=8.1.7",
     "Jinja2>=3.1.3",
-    "toml>=0.10.2",
+    "tomli;python_version<'3.11'",
     "ruamel.yaml>=0.18.6",
 ]
 


### PR DESCRIPTION
Hi,

This is a patch I've applied to the Debian package.

In Debian, we are trying to slowly remove old libraires and/or backports of new libraries.

https://wiki.debian.org/Python/Backports

`tomllib` is a builtin since Python 3.11